### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ almost as [official registering presenter as services](https://api.nette.org/2.4
 
 ## Development
 
-This package was maintain by these authors.
+This package was maintained by these authors.
 
 <a href="https://github.com/f3l1x">
   <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">


### PR DESCRIPTION
## Summary

This PR updates the README to follow the archive style template by fixing a typo in the Development section.

## Changes

- Fixed typo: "was maintain" → "was maintained"

The README was already in archive style format with:
- Deprecation badge with `?deprecated=1` parameter
- Proper disclaimer section pointing to `contributte/di` as replacement
- Composer package info table with badges
- Past tense in Development section (now corrected)

## Notes

The repository was already archived on GitHub and had to be temporarily unarchived to push this change.